### PR TITLE
Update upstream

### DIFF
--- a/annotation/compiler/build.gradle
+++ b/annotation/compiler/build.gradle
@@ -74,10 +74,17 @@ task proguard(type: ProGuardTask, dependsOn: tasks.jarjar) {
     libraryjars "${System.getProperty('java.home')}/lib/rt.jar"
 }
 
-// Create the standard jar artifact based on our compiled, repackaged and proguarded jar.
+// Replace the contents of the standard jar task with those from our our compiled, repackaged and
+// proguarded jar. Replacing the task itself is possible and looks simpler, but requires
+// reconstructing the task dependency chain and is more complex in practice.
 jar {
     dependsOn proguard
     from zipTree(proguardedJar)
+    exclude { entry ->
+        sourceSets.main.output.files*.absolutePath.any {
+            entry.file.absolutePath.startsWith it
+        }
+    }
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ subprojects {
         sourceCompatibility = 1.7
         targetCompatibility = 1.7
     }
+
+    // Avoid issues like #2452.
+    tasks.withType(Jar) {
+        duplicatesStrategy = DuplicatesStrategy.FAIL
+    }
 }
 
 subprojects { project ->


### PR DESCRIPTION
Unless you override the jar task completely, any files you specified are
added to the original files, not replaced. To make matters worse, gradle
does not fail jar tasks when duplicate classes are added by default.

We’ve fixed the immediate issue with compiler’s jar file by excluding classes that do not originate from our repackaged/proguarded jar to 
avoid duplicate class files.We’ve hopefully also prevented future occurrences by forcing all jar tasks in the project to fail by default 
if duplicate classes are added.

Fixes #2452.

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->