### PR TITLE
MOE automated commit.

### DIFF
--- a/instrumentation/src/androidTest/java/com/bumptech/glide/test/CanonicalBitmap.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/test/CanonicalBitmap.java
@@ -6,7 +6,6 @@ import android.graphics.BitmapFactory;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.test.InstrumentationRegistry;
-import com.bumptech.glide.instrumentation.R;
 import com.bumptech.glide.util.Preconditions;
 
 public final class CanonicalBitmap {
@@ -41,7 +40,8 @@ public final class CanonicalBitmap {
     Context context = InstrumentationRegistry.getTargetContext();
     BitmapFactory.Options options = new BitmapFactory.Options();
     options.inScaled = false;
-    Bitmap result = BitmapFactory.decodeResource(context.getResources(), R.raw.canonical, options);
+    int resourceId = ResourceIds.raw.canonical;
+    Bitmap result = BitmapFactory.decodeResource(context.getResources(), resourceId, options);
     if (scaleFactor != null) {
       result = Bitmap.createScaledBitmap(
           result,

--- a/instrumentation/src/androidTest/java/com/bumptech/glide/test/ResourceIds.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/test/ResourceIds.java
@@ -15,6 +15,7 @@ public final class ResourceIds {
 
   public interface raw {
     int dl_world_anim = getResourceId("raw", "dl_world_anim");
+    int canonical = getResourceId("raw", "canonical");
   }
 
   public interface drawable {


### PR DESCRIPTION
Use ResourceIds instead of depending on R.raw.canonical in 
CanonicalBitmap.

-------------
Created by MOE: https://github.com/google/moe
MOE_MIGRATED_REVID=173974844

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->