### PR TITLE
Fail early if getExtendedNominal is called before extension

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 org.gradle.daemon=true
 org.gradle.configureondemand=false
 
-VERSION_NAME=4.10.0
+VERSION_NAME=4.11.0-SNAPSHOT
 VERSION_MAJOR=4
-VERSION_MINOR=10
+VERSION_MINOR=11
 VERSION_PATCH=0
 GROUP=com.github.bumptech.glide
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->